### PR TITLE
Fixes issue-4 when PATH_INFO was passed

### DIFF
--- a/src/Aura/Framework/Web/Front.php
+++ b/src/Aura/Framework/Web/Front.php
@@ -172,7 +172,7 @@ class Front
     public function request()
     {
         // match to a route
-        $path   = $this->context->getServer('PATH_INFO', '/');
+        $path   = $this->context->getServer('REQUEST_URI', '/');
         $server = $this->context->getServer();
         $route  = $this->router->match($path, $server);
         


### PR DESCRIPTION
I was having issues running tests.

Have 10 failures for rmdir . I feel its permission issues .

I was running from 

```
Aura.Framework/tests$ phpunit
```

Anyway this not regarding running tests .

Its a PR for https://github.com/auraphp/Aura.Framework/issues/4 

Changing `PATH_INFO` to `REQUEST_URI` fixes when the server is started via php command line. Also PATH_INFO only available for apache , so ngix will also have issues ?
