### PR TITLE
Suppress the error thrown on trying to remove the directory . ( dot )

### DIFF
--- a/tests/Aura/Framework/Mock/System.php
+++ b/tests/Aura/Framework/Mock/System.php
@@ -38,7 +38,7 @@ class System extends RealSystem
         );
         foreach ($iterator as $path) {
             if ($path->isDir()) {
-                rmdir($path->__toString());
+                @rmdir($path->__toString());
             } else {
                 unlink($path->__toString());
             }


### PR DESCRIPTION
The unit tests for Aura.Framework was failing dude to the error thrown removing directory in test.

Now suppressed.
