### PR TITLE
Accept type

### DIFF
--- a/src/Aura/Framework/Web/Renderer/AuraViewTwoStep.php
+++ b/src/Aura/Framework/Web/Renderer/AuraViewTwoStep.php
@@ -129,7 +129,7 @@ class AuraViewTwoStep extends AbstractRenderer
         $response = $this->controller->getResponse();
         if (! $response->getContent()) {
             $this->twostep->setData((array) $this->controller->getData());
-            $this->twostep->setAccept($this->controller->getContext()->getAccept());
+            $this->twostep->setAccept($this->controller->getContext()->getAccept('type'));
             $this->twostep->setInnerView($this->controller->getView());
             $this->twostep->setOuterView($this->controller->getLayout());
             $response->setContent($this->twostep->render());


### PR DESCRIPTION
Note : The test fails 

I have added 

```
$_SERVER['HTTP_ACCEPT'] = 'text/*;q=0.9, text/html ,text/xhtml;q=0.8';
```

to `Aura\Framework\Web\Hello\PageTest` . But it didn't find a success .

This resolves the bug #10#issuecomment-7748185

```
$curl -i http://localhost:8000/fb/login -H "Accept: application/json"
HTTP/1.1 200
Host: localhost:8000
Connection: close
X-Powered-By: PHP/5.4.4-1~oneiric+1
Content-Type: application/json

{"hello":"World","hello1":"World1","hello2":"World2"}
```
