### PR TITLE
Directory Separator Fix for Unit Tests

### DIFF
--- a/tests/Aura/Framework/InflectTest.php
+++ b/tests/Aura/Framework/InflectTest.php
@@ -48,13 +48,13 @@ class InflectTest extends \PHPUnit_Framework_TestCase
     {
         // used PSR-0 spec as a base
         $list = [
-            'Doctrine\Common\IsolatedClassLoader'   => 'Doctrine/Common/IsolatedClassLoader.php',
-            'Symfony\Core\Request'                  => 'Symfony/Core/Request.php',
+            'Doctrine\Common\IsolatedClassLoader'   => 'Doctrine' . DIRECTORY_SEPARATOR . 'Common' . DIRECTORY_SEPARATOR . 'IsolatedClassLoader.php',
+            'Symfony\Core\Request'                  => 'Symfony' . DIRECTORY_SEPARATOR . 'Core' . DIRECTORY_SEPARATOR . 'Request.php',
             'Zend'                                  => 'Zend.php',
-            'Zend\Acl'                              => 'Zend/Acl.php',
-            'Zend\Mail\Message'                     => 'Zend/Mail/Message.php',
-            'aura\package\ClassName'               => 'aura/package/ClassName.php',
-            'aura\pkg_name\Class_Name'             => 'aura/pkg_name/Class/Name.php',
+            'Zend\Acl'                              => 'Zend' . DIRECTORY_SEPARATOR . 'Acl.php',
+            'Zend\Mail\Message'                     => 'Zend' . DIRECTORY_SEPARATOR . 'Mail' . DIRECTORY_SEPARATOR . 'Message.php',
+            'aura\package\ClassName'               => 'aura' . DIRECTORY_SEPARATOR . 'package' . DIRECTORY_SEPARATOR . 'ClassName.php',
+            'aura\pkg_name\Class_Name'             => 'aura' . DIRECTORY_SEPARATOR . 'pkg_name' . DIRECTORY_SEPARATOR . 'Class' . DIRECTORY_SEPARATOR . 'Name.php',
         ];
         
         foreach ($list as $class => $expect) {

--- a/tests/Aura/Framework/SystemTest.php
+++ b/tests/Aura/Framework/SystemTest.php
@@ -50,7 +50,7 @@ class SystemTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetPackagePath()
     {
-        $expect = 'vfs://root/package';
+        $expect = 'vfs://root' . DIRECTORY_SEPARATOR . 'package';
         $actual = $this->system->getPackagePath();
         $this->assertSame($expect, $actual);
         
@@ -66,7 +66,7 @@ class SystemTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetTmpPath()
     {
-        $expect = 'vfs://root/tmp';
+        $expect = 'vfs://root' . DIRECTORY_SEPARATOR . 'tmp';
         $actual = $this->system->getTmpPath();
         $this->assertSame($expect, $actual);
         
@@ -82,7 +82,7 @@ class SystemTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetWebPath()
     {
-        $expect = 'vfs://root/web';
+        $expect = 'vfs://root' . DIRECTORY_SEPARATOR . 'web';
         $actual = $this->system->getWebPath();
         $this->assertSame($expect, $actual);
         
@@ -98,7 +98,7 @@ class SystemTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetConfigPath()
     {
-        $expect = 'vfs://root/config';
+        $expect = 'vfs://root' . DIRECTORY_SEPARATOR . 'config';
         $actual = $this->system->getConfigPath();
         $this->assertSame($expect, $actual);
         
@@ -114,7 +114,7 @@ class SystemTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetIncludePath()
     {
-        $expect = 'vfs://root/include';
+        $expect = 'vfs://root' . DIRECTORY_SEPARATOR . 'include';
         $actual = $this->system->getIncludePath();
         $this->assertSame($expect, $actual);
         
@@ -128,7 +128,7 @@ class SystemTest extends \PHPUnit_Framework_TestCase
     public function testGetVendorPath()
     {
 
-        $expect = 'vfs://root/vendor';
+        $expect = 'vfs://root' . DIRECTORY_SEPARATOR . 'vendor';
         $actual = $this->system->getVendorPath();
         $this->assertSame($expect, $actual);
 


### PR DESCRIPTION
Replaced static Unix-Style Directory Seperators with dynamic ones from PHPs DIRECTORY_SEPARATOR Constant
Previously all phpunit tests would fail on Windows Machines
