### PR TITLE
Fix loading of system config files

### DIFF
--- a/src/Aura/Framework/Bootstrap/Factory.php
+++ b/src/Aura/Framework/Bootstrap/Factory.php
@@ -242,7 +242,7 @@ class Factory
      * @return void
      * 
      */
-    protected function readConfigSet(callable $read, $mode, $path)
+    public function readConfigSet(callable $read, $mode, $path)
     {
         // Default config file
         $files = [$path . DIRECTORY_SEPARATOR . 'default.php'];

--- a/tests/Aura/Framework/Bootstrap/FactoryTest.php
+++ b/tests/Aura/Framework/Bootstrap/FactoryTest.php
@@ -40,4 +40,49 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $bootstrap = $this->factory->newInstance('mock');
         $this->assertInstanceOf('Aura\Framework\Mock\Bootstrap', $bootstrap);
     }
+
+    /**
+     * This will test to ensure that config files are loaded in the 
+     * proper order (ie default.php >> test.php >> local.php)
+     * 
+     * @covers Aura\Framework\Bootstrap::readConfigSet
+     */
+    public function testReadConfigSet()
+    {
+        // Mode to load
+        $mode = 'test';
+
+        // Actual loaded files
+        $loaded_files = [];
+
+        // Expected loaded files
+        $expected_files = [
+            'default',
+            $mode,
+            'local',
+        ];
+
+        // Method to read the config file
+        $read = function($file) use (&$loaded_files) {
+            require $file;
+        };
+
+        // Setup filesystem
+        $path = VfsSystem::create('root');
+
+        $config_path = $path . DIRECTORY_SEPARATOR . 'config';
+
+        // Create config files to be read
+        foreach($expected_files as $file) {
+            file_put_contents(
+                $config_path . DIRECTORY_SEPARATOR . "{$file}.php",
+                "<?php \$loaded_files[]='{$file}';"
+            );
+        }
+        
+        // Read the config files
+        $this->factory->readConfigSet($read, $mode, $config_path);
+
+        $this->assertEquals($expected_files, $loaded_files);
+    }
 }


### PR DESCRIPTION
Fixed loading of system config files. $mode in the system-wide config now does not load twice. The system-wide default.php config file will always load before $mode config. Added local.php config loading for both system-wide and package-level.
